### PR TITLE
feature/selectable-hint-type

### DIFF
--- a/@AresModAchillesExpansion/addons/language_f/stringtable.xml
+++ b/@AresModAchillesExpansion/addons/language_f/stringtable.xml
@@ -1760,9 +1760,21 @@
                 <Russian>Сообщение</Russian>
                 <German>Mitteilung</German>
             </Key>
-            <Key ID="STR_AMAE_HINTTYPE">
+            <Key ID="STR_AMAE_HINT_TYPE">
                 <Original>Hint Type</Original>
                 <English>Hint Type</English>
+            </Key>
+            <Key ID="STR_AMAE_HINT">
+                <Original>Hint</Original>
+                <English>Hint</English>
+            </Key>
+            <Key ID="STR_AMAE_HINT_SILENT">
+                <Original>Hint Silent</Original>
+                <English>Hint Silent</English>
+            </Key>
+            <Key ID="STR_AMAE_HINT_CADET">
+                <Original>Hint Cadet</Original>
+                <English>Hint Cadet</English>
             </Key>
             <Key ID="STR_AMAE_AI">
                 <Original>AI</Original>

--- a/@AresModAchillesExpansion/addons/language_f/stringtable.xml
+++ b/@AresModAchillesExpansion/addons/language_f/stringtable.xml
@@ -1760,6 +1760,10 @@
                 <Russian>Сообщение</Russian>
                 <German>Mitteilung</German>
             </Key>
+            <Key ID="STR_AMAE_HINTTYPE">
+                <Original>Hint Type</Original>
+                <English>Hint Type</English>
+            </Key>
             <Key ID="STR_AMAE_AI">
                 <Original>AI</Original>
                 <English>AI</English>

--- a/@AresModAchillesExpansion/addons/modules_f_ares/Zeus/functions/fn_ZeusHint.sqf
+++ b/@AresModAchillesExpansion/addons/modules_f_ares/Zeus/functions/fn_ZeusHint.sqf
@@ -13,21 +13,23 @@ private _dialogResult =
 	]
 ] call Ares_fnc_ShowChooseDialog;
 
-if ((_dialogResult select 0) isEqualTo []) exitWith {};
+if (_dialogResult isEqualTo []) exitWith {};
 
-switch (_dialogResult select 0) do 
+_dialogResult params ["_hintType", "_message"];
+
+switch (_hintType) do 
 {
 	case 0: 
 	{
-		parseText (_dialogResult select 1) remoteExec ["hint", 0];
+		parseText (_message) remoteExecCall ["hint", 0];
 	};
 	case 1: 
 	{
-		parseText (_dialogResult select 1) remoteExec ["hintSilent", 0];
+		parseText (_message) remoteExecCall ["hintSilent", 0];
 	};
 	case 2: 
 	{
-		 parseText (_dialogResult select 1) remoteExec ["hintCadet", 0];
+		 parseText (_message) remoteExecCall ["hintCadet", 0];
 	};
 };
 

--- a/@AresModAchillesExpansion/addons/modules_f_ares/Zeus/functions/fn_ZeusHint.sqf
+++ b/@AresModAchillesExpansion/addons/modules_f_ares/Zeus/functions/fn_ZeusHint.sqf
@@ -4,12 +4,31 @@ private _dialogResult =
 [
 	localize "STR_AMAE_HINT",
 	[
-		[localize "STR_AMAE_MESSAGE", "MESSAGE"]
+		[
+			localize "STR_AMAE_HINTTYPE", [ "Hint",  "HintSilent", "HintCadet"]
+		],
+		[
+			localize "STR_AMAE_MESSAGE", "MESSAGE"
+		]	
 	]
 ] call Ares_fnc_ShowChooseDialog;
 
 if ((_dialogResult select 0) isEqualTo []) exitWith {};
 
-(parseText (_dialogResult select 0)) remoteExec ["Hint", 0];
+switch (_dialogResult select 0) do 
+{
+	case 0: 
+	{
+		parseText (_dialogResult select 1) remoteExec ["hint", 0];
+	};
+	case 1: 
+	{
+		parseText (_dialogResult select 1) remoteExec ["hintSilent", 0];
+	};
+	case 2: 
+	{
+		 parseText (_dialogResult select 1) remoteExec ["hintCadet", 0];
+	};
+};
 
 #include "\achilles\modules_f_ares\module_footer.hpp"

--- a/@AresModAchillesExpansion/addons/modules_f_ares/Zeus/functions/fn_ZeusHint.sqf
+++ b/@AresModAchillesExpansion/addons/modules_f_ares/Zeus/functions/fn_ZeusHint.sqf
@@ -21,15 +21,15 @@ switch (_hintType) do
 {
 	case 0: 
 	{
-		parseText (_message) remoteExecCall ["hint", 0];
+		[parseText _message] remoteExecCall ["hint", 0];
 	};
 	case 1: 
 	{
-		parseText (_message) remoteExecCall ["hintSilent", 0];
+		[parseText _message] remoteExecCall ["hintSilent", 0];
 	};
 	case 2: 
 	{
-		 parseText (_message) remoteExecCall ["hintCadet", 0];
+		[parseText _message] remoteExecCall ["hintCadet", 0];
 	};
 };
 

--- a/@AresModAchillesExpansion/addons/modules_f_ares/Zeus/functions/fn_ZeusHint.sqf
+++ b/@AresModAchillesExpansion/addons/modules_f_ares/Zeus/functions/fn_ZeusHint.sqf
@@ -5,7 +5,7 @@ private _dialogResult =
 	localize "STR_AMAE_HINT",
 	[
 		[
-			localize "STR_AMAE_HINTTYPE", [ "Hint",  "HintSilent", "HintCadet"]
+			localize "STR_AMAE_HINTTYPE", [localize "STR_AMAE_HINT",  localize "STR_AMAE_HINT_SILENT", localize "STR_AMAE_HINT_CADET"]
 		],
 		[
 			localize "STR_AMAE_MESSAGE", "MESSAGE"


### PR DESCRIPTION
**When merged this pull request will:**
- Adds a new control in the dialog that pops up when the user places down the hint module that allows the user to select the type of hint that they want to display.
- Adds a new entry in the string table for the new control.

![20180101170630_1](https://user-images.githubusercontent.com/26076132/34471737-37d829e6-ef16-11e7-991a-0f4a545f54b8.jpg)

**Note:** I don't know whether it's better to create entries for the options in the stringtable and use simplified names or use the actual command names in code for the hint types in the drop down control.