### PR TITLE
Change/change-abilities-module-tweak

### DIFF
--- a/@AresModAchillesExpansion/addons/functions_f_achilles/functions/changeAttributes/fn_changeAbility.sqf
+++ b/@AresModAchillesExpansion/addons/functions_f_achilles/functions/changeAttributes/fn_changeAbility.sqf
@@ -44,11 +44,12 @@ if (isNull (_units select 0)) then
 {
 	_units = [localize "STR_AMAE_UNITS"] call Achilles_fnc_SelectUnits;
 };
-if (isNil "_units") exitWith {};
-if (_units isEqualTo []) exitWith {};
+
+if (isNil "_units" || _units isEqualTo []) exitWith {};
 
 {
 	private _unit = _x;
+	if (isPlayer _unit) exitWith {[localize "STR_AMAE_SELECT_NON_PLAYER_UNITS"] call Achilles_fnc_ShowZeusErrorMessage;};
 	{
 		private _ability_type = _x;
 		private _mode = _dialogResult select _forEachIndex;

--- a/@AresModAchillesExpansion/addons/functions_f_achilles/functions/changeAttributes/fn_changeAbility.sqf
+++ b/@AresModAchillesExpansion/addons/functions_f_achilles/functions/changeAttributes/fn_changeAbility.sqf
@@ -48,13 +48,8 @@ if (isNull (_units select 0)) then
 if (isNil "_units" || _units isEqualTo []) exitWith {};
 
 {
-	if (isPlayer _x) exitWith {
-		[localize "STR_AMAE_SELECT_NON_PLAYER_UNITS"] call Achilles_fnc_ShowZeusErrorMessage;
-	};
-} forEach _units;
-
-{
 	private _unit = _x;
+	if (isPlayer _x) exitWith {[localize "STR_AMAE_SELECT_NON_PLAYER_UNITS"] call Achilles_fnc_ShowZeusErrorMessage;};
 	{
 		private _ability_type = _x;
 		private _mode = _dialogResult select _forEachIndex;

--- a/@AresModAchillesExpansion/addons/functions_f_achilles/functions/changeAttributes/fn_changeAbility.sqf
+++ b/@AresModAchillesExpansion/addons/functions_f_achilles/functions/changeAttributes/fn_changeAbility.sqf
@@ -49,7 +49,7 @@ if (isNil "_units" || _units isEqualTo []) exitWith {};
 
 {
 	private _unit = _x;
-	if (isPlayer _x) exitWith {[localize "STR_AMAE_SELECT_NON_PLAYER_UNITS"] call Achilles_fnc_ShowZeusErrorMessage;};
+	if (isPlayer _unit) exitWith {[localize "STR_AMAE_SELECT_NON_PLAYER_UNITS"] call Achilles_fnc_ShowZeusErrorMessage};
 	{
 		private _ability_type = _x;
 		private _mode = _dialogResult select _forEachIndex;

--- a/@AresModAchillesExpansion/addons/functions_f_achilles/functions/changeAttributes/fn_changeAbility.sqf
+++ b/@AresModAchillesExpansion/addons/functions_f_achilles/functions/changeAttributes/fn_changeAbility.sqf
@@ -48,8 +48,13 @@ if (isNull (_units select 0)) then
 if (isNil "_units" || _units isEqualTo []) exitWith {};
 
 {
+	if (isPlayer _x) exitWith {
+		[localize "STR_AMAE_SELECT_NON_PLAYER_UNITS"] call Achilles_fnc_ShowZeusErrorMessage;
+	};
+} forEach _units;
+
+{
 	private _unit = _x;
-	if (isPlayer _unit) exitWith {[localize "STR_AMAE_SELECT_NON_PLAYER_UNITS"] call Achilles_fnc_ShowZeusErrorMessage;};
 	{
 		private _ability_type = _x;
 		private _mode = _dialogResult select _forEachIndex;

--- a/@AresModAchillesExpansion/addons/language_f/stringtable.xml
+++ b/@AresModAchillesExpansion/addons/language_f/stringtable.xml
@@ -1251,6 +1251,10 @@
                 <Russian>Игрок не выбран!</Russian>
                 <German>Keine Spieler ausgewählt!</German>
             </Key>
+            <Key ID="STR_AMAE_SELECT_NON_PLAYER_UNITS">
+                <Original>Select non player units only!</Original>
+                <English>Select non player units only!</English>
+            </Key>
             <Key ID="STR_AMAE_NOT_IMPLEMENTED_AT_THE_MOMENT">
                 <Original>Not implemented at the moment!</Original>
                 <English>Not implemented at the moment!</English>

--- a/@AresModAchillesExpansion/addons/modules_f_achilles/Behaviours/functions/fn_BehaviourChangeAbility.sqf
+++ b/@AresModAchillesExpansion/addons/modules_f_achilles/Behaviours/functions/fn_BehaviourChangeAbility.sqf
@@ -11,6 +11,12 @@
 
 private _units = [_logic, false] call Ares_fnc_GetUnitUnderCursor;
 
+{
+	if (isPlayer _x) exitWith {
+		[localize "STR_AMAE_SELECT_NON_PLAYER_UNITS"] call Achilles_fnc_ShowZeusErrorMessage;
+	} 
+} forEach _units;
+
 [_units] call Achilles_fnc_changeAbility;
 
 #include "\achilles\modules_f_ares\module_footer.hpp"

--- a/@AresModAchillesExpansion/addons/modules_f_achilles/Behaviours/functions/fn_BehaviourChangeAbility.sqf
+++ b/@AresModAchillesExpansion/addons/modules_f_achilles/Behaviours/functions/fn_BehaviourChangeAbility.sqf
@@ -9,14 +9,8 @@
 
 #include "\achilles\modules_f_ares\module_header.hpp"
 
-private _units = [_logic, false] call Ares_fnc_GetUnitUnderCursor;
+private _unit = [_logic, false] call Ares_fnc_GetUnitUnderCursor;
 
-{
-	if (isPlayer _x) exitWith {
-		[localize "STR_AMAE_SELECT_NON_PLAYER_UNITS"] call Achilles_fnc_ShowZeusErrorMessage;
-	} 
-} forEach _units;
-
-[_units] call Achilles_fnc_changeAbility;
+[_unit] call Achilles_fnc_changeAbility;
 
 #include "\achilles\modules_f_ares\module_footer.hpp"

--- a/@AresModAchillesExpansion/addons/ui_f/functions/common/fn_SelectUnits.sqf
+++ b/@AresModAchillesExpansion/addons/ui_f/functions/common/fn_SelectUnits.sqf
@@ -2,7 +2,7 @@
 //	AUTHOR: Kex
 //	DATE: 5/1/16
 //	VERSION: 1.0
-//	FILE: Achilles\functions\fn_SelectObjects.sqf
+//	FILE: Achilles\functions\fn_SelectUnits.sqf
 //  DESCRIPTION: Let the curator select units and submit the selection
 //
 //	ARGUMENTS:


### PR DESCRIPTION
**When merged this pull request will:**
- Implements a check on the change abilities module that prevents it from being placed on players as It did nothing and could potentially confuse users.
- Renamed a misleading variable name inside of the modules function to indicate that it is a single object rather then an array.
- Added a new entry to the string table in order to localize a new error message that is shown when the module is placed on a player.

**Known Issues:** The warning message is not shown when a mass selection including the player is submitted as the selection submitted text will overwrite the error message text though the error sound will still play. The warning message will only show if the module is placed directly on a player.